### PR TITLE
feat(cervix): add optional tilt dimension — body-vulva-cervix-position v1 → v2 (plan 70 phase E)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added (plan 70 phase E — `tilt` dimension on cervix-position)
+- `body-vulva-cervix-position` item bumped `version: v1` → `v2`. Adds an optional fourth composite dimension `tilt` (Straight / Medium / Tilted → 0.0 / 0.5 / 1.0). Position-only (not a fertility signal); RYB-originated — no clinical-coding convention. Old events read identically (eventType name unchanged); new events may carry the optional field.
+- `cervix-position/3d-vectors` eventType schema extended with optional `tilt` property (range 0–1). Existing height/firmness/openness unchanged. Description updated to flag tilt as position-only.
+- `documentation/CERVICAL-POSITION.md` — Read Your Body added to the value-vocabulary table as the only system surveyed that tracks tilt; new section on the v1→v2 additive extension; tilt row added to the HDS model summary.
+- Version bumped 1.8.1 → 1.9.0 (minor — additive schema change).
+
 ### Added (plan 53 phase A — `role: context` flag on context streams)
 - New optional `role` field on stream definitions. v1 value: `context`. A `role: context` stream exists purely as a descendant-streamId marker for the D3 context-via-substream mechanic (see `documentation/TREATMENT-PROCEDURE.md`); no itemDef is registered there and consumers should treat it as metadata, not as a data-bearing bucket.
 - `treatment-fertility` and `procedure-fertility` tagged `role: context`. Implicit default for all other streams is "data" (no declaration required).

--- a/definitions/eventTypes/eventTypes-hds.json
+++ b/definitions/eventTypes/eventTypes-hds.json
@@ -671,7 +671,7 @@
       }
     },
     "cervix-position/3d-vectors": {
-      "description": "Cervical position observation as three 0–1 vectors: height (low→high), firmness (firm→soft), openness (closed→open). Each dimension follows the fertility direction (0 = least fertile, 1 = most fertile).",
+      "description": "Cervical position observation as up to four 0–1 vectors: height (low→high), firmness (firm→soft), openness (closed→open) follow the SHOW fertility direction (0 = least fertile, 1 = most fertile). Optional tilt (straight→tilted) is a position-only field, not a fertility signal — RYB-originated; no clinical-coding convention exists.",
       "type": "object",
       "properties": {
         "height": {
@@ -688,6 +688,12 @@
         },
         "openness": {
           "description": "Cervical os openness: 0 = closed, 0.5 = medium, 1 = open",
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "tilt": {
+          "description": "Cervix tilt: 0 = straight, 0.5 = medium, 1 = tilted. Position-only — not a fertility signal. Added in body-vulva-cervix-position v2 (RYB-originated; no clinical-coding convention).",
           "type": "number",
           "minimum": 0,
           "maximum": 1

--- a/definitions/items/body-vulva.yaml
+++ b/definitions/items/body-vulva.yaml
@@ -181,13 +181,13 @@ body-vulva-menstrual-cup:
 ## Cervical Position
 
 body-vulva-cervix-position:
-  version: v1
+  version: v2
   label:
     en: Cervical Position
     fr: Position du col utérin
   description:
-    en: Self-checked cervix — height, firmness, and openness.
-    fr: Col auto-examiné — hauteur, fermeté et ouverture.
+    en: Self-checked cervix — height, firmness, openness, and tilt.
+    fr: Col auto-examiné — hauteur, fermeté, ouverture et inclinaison.
   streamId: body-vulva-cervix-position
   eventType: cervix-position/3d-vectors
   type: composite
@@ -249,4 +249,23 @@ body-vulva-cervix-position:
           label:
             en: Open
             fr: Ouvert
+    tilt:
+      label:
+        en: Tilt
+        fr: Inclinaison
+      type: select
+      canBeNull: true
+      options:
+        - value: 0.0
+          label:
+            en: Straight
+            fr: Droit
+        - value: 0.5
+          label:
+            en: Medium
+            fr: Moyen
+        - value: 1.0
+          label:
+            en: Tilted
+            fr: Incliné
   repeatable: P1D

--- a/documentation/CERVICAL-POSITION.md
+++ b/documentation/CERVICAL-POSITION.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Cervical position self-assessment is used in fertility awareness methods. All systems that track it agree on **3 dimensions**:
+Cervical position self-assessment is used in fertility awareness methods. The three core dimensions tracked across all major systems:
 
 | Dimension | Clinical meaning | Fertility signal |
 |-----------|-----------------|-----------------|
@@ -10,21 +10,28 @@ Cervical position self-assessment is used in fertility awareness methods. All sy
 | **Firmness** (texture) | Tissue firmness on palpation | Soft = fertile |
 | **Openness** (os dilation) | Cervical os opening | Open = fertile |
 
+HDS v2 adds an optional 4th dimension — **tilt** — for parity with apps that track it (RYB). Tilt is **not a fertility signal** and has no clinical-coding convention.
+
+| Dimension | Clinical meaning | Fertility signal |
+|-----------|-----------------|-----------------|
+| **Tilt** (anteversion/retroversion) | Cervix orientation | None — position-only |
+
 ## Value Vocabularies by System
 
-| System | Height | Firmness | Openness | Notes |
-|--------|--------|----------|----------|-------|
-| **Fertility Friend** | Low, Medium, High | Firm, Medium, Soft | Closed, Medium, Open | 3x3x3, reference standard |
-| **Ovia** | Low, Medium, High | Hard, Medium, Soft | Closed, Medium, Open | 3x3x3, uses "Hard" not "Firm" |
-| **TCOYF (Weschler)** | Low, High | Firm, Soft | Closed, Open | 2x2x2 binary model |
-| **Mira** | "Middle", ? | "Medium", ? | "Closed", ? | Only 1 sample value per dim |
-| **Kindara** | height + softness + openness | — | — | Confirmed 3 dimensions |
-| **Flo** | educational only (SHOW) | — | — | No structured tracking found |
-| **Clue** | — | — | — | Cervical fluid only, no position |
-| **Natural Cycles** | — | — | — | Cervical mucus only |
-| **Tempdrop** | — | — | — | Cervical mucus only |
-| **Apple HealthKit** | **N/A** | **N/A** | **N/A** | No cervical position API |
-| **SNOMED/FHIR** | **N/A** | **N/A** | **N/A** | No self-assessed position codes |
+| System | Height | Firmness | Openness | Tilt | Notes |
+|--------|--------|----------|----------|------|-------|
+| **Fertility Friend** | Low, Medium, High | Firm, Medium, Soft | Closed, Medium, Open | — | 3x3x3, reference standard for first 3 |
+| **Ovia** | Low, Medium, High | Hard, Medium, Soft | Closed, Medium, Open | — | 3x3x3, uses "Hard" not "Firm" |
+| **TCOYF (Weschler)** | Low, High | Firm, Soft | Closed, Open | — | 2x2x2 binary model |
+| **Mira** | "Middle", ? | "Medium", ? | "Closed", ? | — | Only 1 sample value per dim |
+| **Kindara** | height + softness + openness | — | — | — | Confirmed 3 dimensions |
+| **Flo** | educational only (SHOW) | — | — | — | No structured tracking found |
+| **Clue** | — | — | — | — | Cervical fluid only, no position |
+| **Natural Cycles** | — | — | — | — | Cervical mucus only |
+| **Tempdrop** | — | — | — | — | Cervical mucus only |
+| **Read Your Body** | Low, Medium, High | Firm, Medium, Soft | Closed, Medium, Open | Straight, Medium, Tilted | **Only system surveyed that tracks tilt** |
+| **Apple HealthKit** | **N/A** | **N/A** | **N/A** | **N/A** | No cervical position API |
+| **SNOMED/FHIR** | **N/A** | **N/A** | **N/A** | **N/A** | No self-assessed position codes |
 
 ## SHOW Mnemonic (Toni Weschler, "Taking Charge of Your Fertility")
 
@@ -52,13 +59,13 @@ Infertile = Firm (like nose tip), Low, Closed, Dry
 
 ## HDS Model
 
-Single item `body-vulva-cervix-position` with event type `cervix-position/3d-vectors`.
+Single item `body-vulva-cervix-position` with event type `cervix-position/3d-vectors` (eventType name unchanged across v1 → v2 — the schema is additive; old events read identically).
 
-Scale direction: **0.0 = least fertile, 1.0 = most fertile** (consistent with SHOW mnemonic).
+Scale direction: **0.0 = least fertile, 1.0 = most fertile** for the three core dimensions (SHOW mnemonic). Tilt is **position-only** (0.0 = straight, 1.0 = tilted) — not a fertility signal.
 
-Event content stores all 3 dimensions as an object:
+Event content stores up to 4 dimensions as an object:
 ```json
-{ "height": 1.0, "firmness": 0.0, "openness": 0.5 }
+{ "height": 1.0, "firmness": 0.0, "openness": 0.5, "tilt": 0.5 }
 ```
 
 | Dimension | Values | Mapping |
@@ -66,5 +73,11 @@ Event content stores all 3 dimensions as an object:
 | `height` | Low / Medium / High | 0.0 / 0.5 / 1.0 |
 | `firmness` | Firm / Medium / Soft | 0.0 / 0.5 / 1.0 |
 | `openness` | Closed / Medium / Open | 0.0 / 0.5 / 1.0 |
+| `tilt` (v2+, optional) | Straight / Medium / Tilted | 0.0 / 0.5 / 1.0 |
 
 Item: `type: composite`, `repeatable: P1D`, partial dimensions allowed (only present fields are stored).
+
+## Version history
+
+- **v1** — initial 3-dimension model: height, firmness, openness.
+- **v2** (2026-06-03, plan 70 phase E) — additive: optional `tilt` field. eventType name unchanged (`cervix-position/3d-vectors`) — old events read identically; new events may carry the optional 4th dimension. Consumers should treat absent `tilt` as 3d (no-op render).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hds/data-model",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "HDS data model",
   "main": "src/index.js",
   "engines": {


### PR DESCRIPTION
## Summary

Plan 70 Phase E.1 (data-model side). **Additive extension**: adds an optional fourth dimension `tilt` to the cervical-position composite item. eventType name unchanged (`cervix-position/3d-vectors`) so old events read identically; only the item version flips v1 → v2 to signal the new field's presence.

Direct precedent: `body-vulva-bleeding` v1 → v2 ([`body-vulva.yaml:79`](https://github.com/healthdatasafe/data-model/blob/main/definitions/items/body-vulva.yaml#L79)).

## Why additive (not a new eventType)

Per the workspace-survey analysis recorded in plan 70:
- The existing schema already has optional properties (none of height/firmness/openness are `required`).
- The composite-item renderer in [`eventToShortText.ts:218`](https://github.com/healthdatasafe/hds-lib-js/blob/main/ts/HDSModel/eventToShortText.ts#L218) walks `itemDef.data.composite` keys generically — a new field surfaces automatically.
- No event-type-migration framework exists in hds-lib-js; building one for tilt would dwarf the actual change.
- HealthKit / SNOMED / FHIR have no cervical-position API at all, so there's nothing to align with.

## Tilt — position-only, not a fertility signal

RYB is the only system surveyed (FF / Ovia / TCOYF / Mira / Kindara) that tracks tilt. No clinical-coding convention. Tilt has no SHOW-style "more fertile = X" direction — `straight`/`medium`/`tilted` are just positions. The schema description and the doc both flag this explicitly.

## Files

- [`definitions/items/body-vulva.yaml`](definitions/items/body-vulva.yaml) — `body-vulva-cervix-position` `version: v1` → `v2`, `tilt` composite block added with EN/FR labels.
- [`definitions/eventTypes/eventTypes-hds.json`](definitions/eventTypes/eventTypes-hds.json) — optional `tilt` property (range 0–1) on `cervix-position/3d-vectors`. Description updated.
- [`documentation/CERVICAL-POSITION.md`](documentation/CERVICAL-POSITION.md) — RYB added to the vocabulary table as the only system that tracks tilt; tilt row in the HDS model summary; v1 → v2 version-history section.
- [`package.json`](package.json) — `1.8.1` → `1.9.0` (minor; additive).
- [`CHANGELOG.md`](CHANGELOG.md) — Unreleased ▸ Added entry.

## Test plan

- [x] `npm test` — 45 passing (unchanged from main).
- [ ] **`npm run deploy` after merge** — publishes `dist/pack.json` to `model.datasafe.dev` so consumers see the new tilt field. Per workspace convention.
- [ ] Consumer-side follow-ups (separate PRs): `hds-feminine-cycle-ui/CervixPositionMarker` (tilt rendering), `hds-react-timeline/extraDataModel.ts` (small), `bridge-cycles-files` RYB adapter (write tilt).

## Plan reference

Phase E.1 of plan 70 — [`_plans/70-read-your-body-bridge-atwork/PLAN.md`](https://github.com/healthdatasafe/_macro/blob/main/_plans/70-read-your-body-bridge-atwork/PLAN.md) ▸ "Implementation phases" ▸ "Phase E".